### PR TITLE
Create a valid Unknown1C tag

### DIFF
--- a/Core/OadFile.cs
+++ b/Core/OadFile.cs
@@ -598,7 +598,7 @@ namespace AnimKit.Core
                 };
 
                 anim.Unknown_10h = hasRootMotion ? (byte)16 : (byte)0;
-                anim.Unknown_1Ch = 0; // ???
+                anim.Unknown_1Ch = JenkHash.GenHash(onim.Name.ToLowerInvariant()); //  Unique hash required by game for each anim
 
                 anim.AssignSequenceBoneIds();
 


### PR DESCRIPTION
Many people are still using AnimKit and suffering from the missing game crash or messed up the ped skeleton due to missing unique Unknown1C tag. Game requires a unique Unknown1C for each anim (probably used for caching and referencing the animation). This commit fixes it by using the onim name as the tag.